### PR TITLE
Use Reactify transform when building

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,10 @@
   "dependencies": {
     "react": "^0.12.1",
     "reactify": "^0.17.1"
+  },
+  "browserify": {
+    "transform": [
+      "reactify"
+    ]
   }
 }


### PR DESCRIPTION
The Reactify transform is, by default, not applied to your app's dependencies, so the JSX in react-recaptcha wasn't getting processed. (See andreypopp/reactify#20.) This patch fixes it for me, and according to Andrey, is the correct way to go about this.
